### PR TITLE
add currentState property to track end of media and fix next previous actions

### DIFF
--- a/import/qml/AudioPlayer.qml
+++ b/import/qml/AudioPlayer.qml
@@ -37,7 +37,7 @@ Item {
     property bool titleVisible: true
     property var nextAction
     property var previousAction
-    readonly property var currentState: player.status
+    property alias currentState: player.status
     readonly property bool horizontal: width > switchWidth
 
     onEnabledChanged: syncStatusTimer.restart()

--- a/import/qml/AudioPlayer.qml
+++ b/import/qml/AudioPlayer.qml
@@ -37,6 +37,7 @@ Item {
     property bool titleVisible: true
     property var nextAction
     property var previousAction
+    readonly property var currentState: player.status
     readonly property bool horizontal: width > switchWidth
 
     onEnabledChanged: syncStatusTimer.restart()
@@ -131,7 +132,7 @@ Item {
                     focus: false
                     icon.name: "media-seek-backward"
                     onClicked: {
-                        triggerEvent(previousAction, {})
+                        triggerGuiEvent(previousAction, {})
                         previousButton.focus = false
                     }
                 }
@@ -163,7 +164,7 @@ Item {
                     focus: false
                     icon.name: "media-seek-forward"
                     onClicked: {
-                        triggerEvent(nextAction, {})
+                        triggerGuiEvent(nextAction, {})
                         nextButton.focus = false
                     }
                 }

--- a/import/qml/VideoPlayer.qml
+++ b/import/qml/VideoPlayer.qml
@@ -35,7 +35,7 @@ Item {
     property bool controlBarOpened: false
     property var nextAction
     property var previousAction
-    readonly property var currentState: player.status
+    property alias currentState: player.status
     
     onEnabledChanged: syncStatusTimer.restart()
     onSourceChanged: syncStatusTimer.restart()

--- a/import/qml/VideoPlayer.qml
+++ b/import/qml/VideoPlayer.qml
@@ -33,8 +33,9 @@ Item {
     property bool hasNextAction: true
     property bool hasPreviousAction: true
     property bool controlBarOpened: false
-    property var nextActioncontrolBarOpened
+    property var nextAction
     property var previousAction
+    readonly property var currentState: player.status
     
     onEnabledChanged: syncStatusTimer.restart()
     onSourceChanged: syncStatusTimer.restart()


### PR DESCRIPTION
- Add a readonly property currentState that maps to mediaPlayer.status enum to know the current state of song so a skill writer can auto play next song on end of media.

Example:
```
Mycroft.AudioPlayer {
        onCurrentStateChanged: {
            if(currentState == MediaPlayer.EndOfMedia) {
                triggerGuiEvent("somePlayerSkill.nextSong", {})
            }
      }
}
```

- Fix AudioPlayer.qml nextAction and previousAction update it from triggerEvent() to triggerGuiEvent()