### PR TITLE
set focus on delegate on skill view key navigation

### DIFF
--- a/import/qml/SkillView.qml
+++ b/import/qml/SkillView.qml
@@ -179,9 +179,11 @@ Mycroft.AbstractSkillView {
 
                     Keys.onLeftPressed: {
                         delegatesView.currentIndex--
+                        delegatesView.currentItem.contentItem.forceActiveFocus()
                     }
                     Keys.onRightPressed: {
                         delegatesView.currentIndex++
+                        delegatesView.currentItem.contentItem.forceActiveFocus()
                     }
 
                     Connections {


### PR DESCRIPTION
Currently on basic key navigation focus is not set on the delegate.
- Adds focus to page when page is changed.