### PR TITLE
Add hasShadow property to StatusIndicator

### DIFF
--- a/import/qml/StatusIndicator.qml
+++ b/import/qml/StatusIndicator.qml
@@ -25,6 +25,8 @@ Item {
     id: root
     implicitWidth: Kirigami.Units.gridUnit * 5
     implicitHeight: width
+    
+    property bool hasShadow: true
 
     state: "idle"
     states: [
@@ -215,7 +217,7 @@ Item {
         height: width
         color: innerCircle.backgroundColor
         radius: height
-        layer.enabled: true
+        layer.enabled: hasShadow
         layer.effect: DropShadow {
             cached: true
             transparentBorder: true


### PR DESCRIPTION
This property will be useful in situations where a developer wants to use the Mycroft StatusIndicator like a system tray icon since drop shadows aren't normally used on icons in a panel/system tray.