### PR TITLE
Include KDECMakeSettings to set the RPATH settings.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(ECM 1.6.0 REQUIRED NO_MODULE)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${ECM_MODULE_PATH} ${ECM_KDE_MODULE_DIR})
 
 include(KDEInstallDirs)
+include(KDECMakeSettings)
 include(ECMInstallIcons)
 set(CMAKE_AUTOMOC ON)
 


### PR DESCRIPTION
This makes plasma-bigscreen work on my setup (custom prefix for Qt5,
KF5, etc).

Otherwise libmycroftplugin.so would find qtwebsocket from /usr/lib
rather than from the correct Qt dir (version omismatch -> error).