### PR TITLE
Start / stop commands from environment

### DIFF
--- a/data/mycroft-gui-core-loader.in
+++ b/data/mycroft-gui-core-loader.in
@@ -1,3 +1,11 @@
 #!/bin/sh
-cd ${MYCROFT_CORE_DIR}
-./start-mycroft.sh all
+
+#If startup command is defined use it
+if ! test -z "$MYCROFT_START_CMD"; then
+	$MYCROFT_START_CMD
+else
+	# Use default git install location
+	cd ${MYCROFT_CORE_DIR}
+	./start-mycroft.sh all
+fi
+

--- a/data/mycroft-gui-core-stop.in
+++ b/data/mycroft-gui-core-stop.in
@@ -1,3 +1,8 @@
 #!/bin/sh
-cd ${MYCROFT_CORE_DIR}
-./stop-mycroft.sh
+#If stop command is defined use it
+if ! test -z "$MYCROFT_STOP_CMD"; then
+	$MYCROFT_STOP_CMD
+else
+	# Use default git install
+	cd ${MYCROFT_CORE_DIR}
+	./stop-mycroft.sh


### PR DESCRIPTION
To allow the packaged mycroft-core to be launched and stopped from mycroft-gui the load/unload needs to be changeable

This utilizes environment variables to override the default (git clone) installation.
- `MYCROFT_START_CMD` will be used to start the mycroft services if defined
- `MYCROFT_STOP_CMD` will be used to stop the mycroft services if defined