### PR TITLE
Unbreak build desktop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 2.8.12)
 option(BUILD_REMOTE_TTS "Build remote TTS support" OFF)
 set(QT_MIN_VERSION "5.9.0")
 set(KF5_MIN_VERSION "5.50.0")
- 
+
 PROJECT(mycroft-gui)
 
 # Use Extra CMake Modules (ECM) for common functionality.

--- a/autotests/CMakeLists.txt
+++ b/autotests/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ECMAddTests)
 
-find_package(Qt5 ${REQUIRED_QT_VERSION} NO_MODULE REQUIRED Test)
+find_package(Qt5 ${REQUIRED_QT_VERSION} NO_MODULE REQUIRED TextToSpeech Test)
 set_package_properties(Qt5Test PROPERTIES PURPOSE "Required for autotests")
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR}/../import)

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -Ee
 
 # Build
 bash dev_setup.sh

--- a/sync_skills.sh
+++ b/sync_skills.sh
@@ -24,5 +24,8 @@ function sync_from() {
 }
 
 # Read the IP from the mycroft-gui-app
-ip=$( sed -nr "/^\[General\]/ { :l /^webSocketAddress[ ]*=/ { s/.*=[ ]*ws:\/\///; p; q;}; n; b l;}" ~/.config/Unknown\ Organization/mycroft-gui-app.conf )
-sync_from $ip
+FILE=~/.config/Unknown\ Organization/mycroft-gui-app.conf
+if test -f "$FILE"; then
+    ip=$( sed -nr "/^\[General\]/ { :l /^webSocketAddress[ ]*=/ { s/.*=[ ]*ws:\/\///; p; q;}; n; b l;}" $FILE )
+    sync_from $ip
+fi


### PR DESCRIPTION
Qt5::TextToSpeech was just added as a library in android builds but we need it to link against the tests.