### PR TITLE
Fix regexps to read the README files correctly

### DIFF
--- a/application/HintsPage.qml
+++ b/application/HintsPage.qml
@@ -43,8 +43,8 @@ Kirigami.Page {
             var fileParse = Mycroft.FileReader.read(fileName);
             console.log("Loading hints from", fileName);
             var matchedRegex = getDataFromRegex(fileName, fileParse, /<img[^>]*src='([^']*)'.*\/>\s(.*)/g)
-            var matchedExamples = getDataFromRegex(fileName, fileParse, /Examples \n.*"(.*)"\n\*\s"(.*)"/g)
-            var matchedCategory = getDataFromRegex(fileName, fileParse, /## Category\n\*\*(.*)\*\*/g)
+            var matchedExamples = getDataFromRegex(fileName, fileParse, /## Examples.*\n.*"(.*)"\n\*\s"(.*)"/g)
+            var matchedCategory = getDataFromRegex(fileName, fileParse, /## Category.*\n\*\*(.*)\*\*/g)
             if(matchedRegex !== null && matchedRegex.length > 0 && matchedExamples !== null && matchedExamples.length > 0 && matchedCategory !== null && matchedCategory.length > 0) {
                 console.log("All good. \n");
                 var metaFileObject = {


### PR DESCRIPTION
The hints are generated via parsing the README.md files, but the regexp was too restrictive (around 10 skills show the hints for me, but I have around 25 skills) and while developing the skill is really good to be able to quickly look for them.
