### PR TITLE
Replace ~ with $HOME

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,8 +29,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Werror")
 #the Android case is a temporary hack, adjust it to where and android app can find
 if(CMAKE_SYSTEM_NAME STREQUAL "Android")
     set(MYCROFT_CORE_DIR ":")
-else(MYCROFT_CORE_DIR "~/mycroft-core")
-    set(MYCROFT_CORE_DIR "~/mycroft-core")
+else(MYCROFT_CORE_DIR "$HOME/mycroft-core")
+    set(MYCROFT_CORE_DIR "$HOME/mycroft-core")
 endif()
 
 #configure_file(config-mycroft.h.in ${CMAKE_CURRENT_BINARY_DIR}/config-mycroft.h)


### PR DESCRIPTION
Fixes issue with quotes in the start/stop script. `"` will not expand `~` this replaces the `~` with `$HOME`