### PR TITLE
use wakeword instead of begin_recording

### DIFF
--- a/import/mycroftcontroller.cpp
+++ b/import/mycroftcontroller.cpp
@@ -255,6 +255,11 @@ void MycroftController::onMainSocketMessageReceived(const QString &message)
         emit isListeningChanged();
         return;
     }
+    if (type == QLatin1String("recognizer_loop:record_begin") && !m_isListening) {
+        m_isListening = true;
+        emit isListeningChanged();
+        return;
+    }
     if (type == QLatin1String("recognizer_loop:record_end")) {
         m_isListening = false;
         emit isListeningChanged();

--- a/import/mycroftcontroller.cpp
+++ b/import/mycroftcontroller.cpp
@@ -250,7 +250,7 @@ void MycroftController::onMainSocketMessageReceived(const QString &message)
         emit isSpeakingChanged();
         return;
     }
-    if (type == QLatin1String("recognizer_loop:record_begin")) {
+    if (type == QLatin1String("recognizer_loop:wakeword")) {
         m_isListening = true;
         emit isListeningChanged();
         return;


### PR DESCRIPTION
use wakeword event emit as the starting point to display status indicator