### PR TITLE
Add screenTimeoutReceived signal and implement window close on timeout

### DIFF
--- a/application/main.qml
+++ b/application/main.qml
@@ -71,7 +71,7 @@ Kirigami.ApplicationWindow {
             }
         }
         
-        onSkillTimeoutRecieved: {
+        onSkillTimeoutReceived: {
             if(mainView.currentItem.contentItem.skillId() == skillidleid) {
                 root.close()
             }

--- a/application/main.qml
+++ b/application/main.qml
@@ -70,6 +70,12 @@ Kirigami.ApplicationWindow {
                 micButton.clicked()
             }
         }
+        
+        onWindowCloseRecieved: {
+            if(mainView.currentItem.contentItem.skillId() == skillidleid) {
+                root.close()
+            }
+        }
     }
     
     Connections {

--- a/application/main.qml
+++ b/application/main.qml
@@ -71,7 +71,7 @@ Kirigami.ApplicationWindow {
             }
         }
         
-        onWindowCloseRecieved: {
+        onSkillTimeoutRecieved: {
             if(mainView.currentItem.contentItem.skillId() == skillidleid) {
                 root.close()
             }

--- a/import/abstractdelegate.h
+++ b/import/abstractdelegate.h
@@ -169,7 +169,6 @@ public:
      * @internal skill id this delegate belongs to
      */
     void setSkillId(const QString &skillId);
-    QString skillId() const;
 
 public Q_SLOTS:
     /**
@@ -177,6 +176,7 @@ public Q_SLOTS:
      * Is not possible to trigger events belonging to different skills
      */
     void triggerGuiEvent(const QString &eventName, const QVariantMap &parameters);
+    QString skillId() const;
 
 protected:
     void geometryChanged(const QRectF &newGeometry, const QRectF &oldGeometry) override;

--- a/import/mycroftcontroller.cpp
+++ b/import/mycroftcontroller.cpp
@@ -311,7 +311,7 @@ void MycroftController::onMainSocketMessageReceived(const QString &message)
     
     if (type == QLatin1String("screen.close.idle.event")) {
         QString skill_idle_event_id = doc[QStringLiteral("data")][QStringLiteral("skill_idle_event_id")].toString();
-        emit windowCloseRecieved(skill_idle_event_id);
+        emit skillTimeoutRecieved(skill_idle_event_id);
     }
 
     // Check if it's an utterance recognized as an intent

--- a/import/mycroftcontroller.cpp
+++ b/import/mycroftcontroller.cpp
@@ -311,7 +311,7 @@ void MycroftController::onMainSocketMessageReceived(const QString &message)
     
     if (type == QLatin1String("screen.close.idle.event")) {
         QString skill_idle_event_id = doc[QStringLiteral("data")][QStringLiteral("skill_idle_event_id")].toString();
-        emit skillTimeoutRecieved(skill_idle_event_id);
+        emit skillTimeoutReceived(skill_idle_event_id);
     }
 
     // Check if it's an utterance recognized as an intent

--- a/import/mycroftcontroller.cpp
+++ b/import/mycroftcontroller.cpp
@@ -308,6 +308,11 @@ void MycroftController::onMainSocketMessageReceived(const QString &message)
         m_serverReady = true;
         emit serverReadyChanged();
     }
+    
+    if (type == QLatin1String("screen.close.idle.event")) {
+        QString skill_idle_event_id = doc[QStringLiteral("data")][QStringLiteral("skill_idle_event_id")].toString();
+        emit windowCloseRecieved(skill_idle_event_id);
+    }
 
     // Check if it's an utterance recognized as an intent
     if (type.contains(QLatin1Char(':')) && !doc[QStringLiteral("data")][QStringLiteral("utterance")].toString().isEmpty()) {

--- a/import/mycroftcontroller.h
+++ b/import/mycroftcontroller.h
@@ -93,7 +93,7 @@ Q_SIGNALS:
     void fallbackTextRecieved(const QString &skill, const QVariantMap &data);
 
     void utteranceManagedBySkill(const QString &skill);
-    void windowCloseRecieved(const QString &skillidleid);
+    void skillTimeoutRecieved(const QString &skillidleid);
 
 public Q_SLOTS:
     void start();

--- a/import/mycroftcontroller.h
+++ b/import/mycroftcontroller.h
@@ -93,6 +93,7 @@ Q_SIGNALS:
     void fallbackTextRecieved(const QString &skill, const QVariantMap &data);
 
     void utteranceManagedBySkill(const QString &skill);
+    void windowCloseRecieved(const QString &skillidleid);
 
 public Q_SLOTS:
     void start();

--- a/import/mycroftcontroller.h
+++ b/import/mycroftcontroller.h
@@ -93,7 +93,7 @@ Q_SIGNALS:
     void fallbackTextRecieved(const QString &skill, const QVariantMap &data);
 
     void utteranceManagedBySkill(const QString &skill);
-    void skillTimeoutRecieved(const QString &skillidleid);
+    void skillTimeoutReceived(const QString &skillidleid);
 
 public Q_SLOTS:
     void start();


### PR DESCRIPTION
- Adds windowCloseReceived signal emitted on 'screen.close.idle.event'
- Makes skillId() public function accessible from qml for comparison of current skill id and the skill requesting to close window id on timeout event. Needed when two separate windows are displaying two separate skills.