### PR TITLE
trigger user interaction event on key release

### DIFF
--- a/import/abstractdelegate.cpp
+++ b/import/abstractdelegate.cpp
@@ -265,6 +265,11 @@ void AbstractDelegate::mousePressEvent(QMouseEvent *event)
     triggerGuiEvent(QStringLiteral("system.gui.user.interaction"), QVariantMap({{QStringLiteral("skillId"), m_skillId}}));
 }
 
+void AbstractDelegate::keyReleaseEvent(QKeyEvent *event)
+{
+    triggerGuiEvent(QStringLiteral("system.gui.user.interaction"), QVariantMap({{QStringLiteral("skillId"), m_skillId}}));
+}
+
 void AbstractDelegate::focusInEvent(QFocusEvent *event)
 {
     //if the focus came from the server, don't ask the server again

--- a/import/abstractdelegate.h
+++ b/import/abstractdelegate.h
@@ -185,6 +185,7 @@ protected:
     void componentComplete() override;
     bool childMouseEventFilter(QQuickItem *item, QEvent *event) override;
     void mousePressEvent(QMouseEvent *event) override;
+    void keyReleaseEvent(QKeyEvent *event) override;
     void focusInEvent(QFocusEvent *event) override;
 
 Q_SIGNALS:


### PR DESCRIPTION
user interaction event was not sent when interacting with the delegate via only key press, enable sending the user interaction event on key release