### PR TITLE
Translate QML-only messages with QTranslator

### DIFF
--- a/import/abstractdelegate.cpp
+++ b/import/abstractdelegate.cpp
@@ -69,7 +69,8 @@ void DelegateLoader::init(const QString skillId, const QUrl &delegateUrl)
 QUrl DelegateLoader::translationsUrl() const
 {
     QUrl url(m_delegateUrl);
-    url.setPath(m_delegateUrl.path().mid(0, m_delegateUrl.path().lastIndexOf(QLatin1Char('/')) + 1) + QStringLiteral("translations"));
+    url.setPath(m_delegateUrl.path().mid(0, m_delegateUrl.path().indexOf(QStringLiteral("/ui/")) + 4) + QStringLiteral("translations"));
+qWarning()<<"AAAAAAAAAA"<<url;
     return url;
 }
 

--- a/import/abstractdelegate.cpp
+++ b/import/abstractdelegate.cpp
@@ -69,7 +69,7 @@ void DelegateLoader::init(const QString skillId, const QUrl &delegateUrl)
 QUrl DelegateLoader::translationsUrl() const
 {
     QUrl url(m_delegateUrl);
-    url.setPath(m_delegateUrl.path().mid(0, m_delegateUrl.path().indexOf(QLatin1Char('/'), -1)) + QStringLiteral("translations"));
+    url.setPath(m_delegateUrl.path().mid(0, m_delegateUrl.path().lastIndexOf(QLatin1Char('/')) + 1) + QStringLiteral("translations"));
     return url;
 }
 

--- a/import/abstractdelegate.cpp
+++ b/import/abstractdelegate.cpp
@@ -66,6 +66,13 @@ void DelegateLoader::init(const QString skillId, const QUrl &delegateUrl)
     }
 }
 
+QUrl DelegateLoader::translationsUrl() const
+{
+    QUrl url(m_delegateUrl);
+    url.setPath(m_delegateUrl.path().mid(0, m_delegateUrl.path().indexOf(QLatin1Char('/'), -1)) + QStringLiteral("translations"));
+    return url;
+}
+
 void DelegateLoader::createObject()
 {
     QQmlContext *context = QQmlEngine::contextForObject(m_view);

--- a/import/abstractdelegate.cpp
+++ b/import/abstractdelegate.cpp
@@ -70,7 +70,7 @@ QUrl DelegateLoader::translationsUrl() const
 {
     QUrl url(m_delegateUrl);
     url.setPath(m_delegateUrl.path().mid(0, m_delegateUrl.path().indexOf(QStringLiteral("/ui/")) + 4) + QStringLiteral("translations"));
-qWarning()<<"AAAAAAAAAA"<<url;
+
     return url;
 }
 

--- a/import/abstractdelegate.h
+++ b/import/abstractdelegate.h
@@ -38,6 +38,8 @@ public:
 
     void setFocus(bool focus);
 
+    QUrl translationsUrl() const;
+
 Q_SIGNALS:
     void delegateCreated();
 

--- a/import/abstractskillview.h
+++ b/import/abstractskillview.h
@@ -27,6 +27,7 @@ class ActiveSkillsModel;
 class AbstractSkillView;
 class AbstractDelegate;
 class SessionDataMap;
+class QTranslator;
 
 class AbstractSkillView: public QQuickItem
 {
@@ -95,7 +96,8 @@ private:
     QTimer m_trimComponentsTimer;
     QString m_id;
     QUrl m_url;
-    QHash<QString, SessionDataMap*> m_skillData;
+    QHash<QString, SessionDataMap *> m_skillData;
+    QHash<QString, QTranslator *> m_translatorsForSkill;
 
     MycroftController *m_controller;
     QWebSocket *m_guiWebSocket;


### PR DESCRIPTION
Some messages are needed to be in the QML file directly, this means they can't be translated from the python part, so use the internal Qt translation infrastructure.
see https://doc.qt.io/qt-5/qtquick-internationalization.html

All qml files will need to do text messages with the qsTr method call like so:

    Label {
        text: qsTr("Text to be translated")
    }