### PR TITLE
rotation: fix rectangle size and rotation for 90 and 270 degrees

### DIFF
--- a/application/main.qml
+++ b/application/main.qml
@@ -38,6 +38,10 @@ Kirigami.ApplicationWindow {
     y: deviceHeight ? Screen.desktopAvailableHeight - height : undefined
 
     color: "black"
+
+    property var rot_origin_x: globalScreenRotation == 90 || globalScreenRotation == 270 ? height/2 : width/2
+    property var rot_origin_y: globalScreenRotation == 90 || globalScreenRotation == 270 ? width/2 : height/2
+
     //HACK!! needs proper api in kirigami
     Component.onCompleted: {
         globalDrawer.handle.handleAnchor = handleAnchor;
@@ -199,9 +203,12 @@ Kirigami.ApplicationWindow {
             }
         }
         Rectangle {
+            height: globalScreenRotation == 90 || globalScreenRotation == 270 ? root.width : root.height
+            width: globalScreenRotation == 90 || globalScreenRotation == 270 ? root.height : root.width
             color: nightSwitch.checked ? "black" : Kirigami.Theme.backgroundColor
-            rotation: globalScreenRotation || 0
-            anchors.fill: parent
+            transform: Rotation { origin.x: root.rot_origin_x; origin.y: root.rot_origin_y; angle: globalScreenRotation }
+            anchors.centerIn: parent
+
             Image {
                 visible: singleSkill.length === 0
                 source: "background.png"


### PR DESCRIPTION
#### Description
fixes the rotation for 90 and 270 degrees where the size of the rotated rectangle was not correct as shown here 
[forum posting](https://community.mycroft.ai/t/mycroft-gui-on-my-mark-ii-simplified-app/8772/4?u=guhl)

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
_Either delete those that do not apply, or add an x between the square brackets like so: `- [x]`_
- [x] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
run mycroft-gui-app --rotateScreen 90

#### Documentation
none

#### CLA
To protect you, the project, and those who choose to use Mycroft technologies in systems they build, we ask all contributors to sign a Contributor License Agreement.

This agreement clarifies that you are granting a license to the Mycroft Project to freely use your work.  Additionally, it establishes that you retain the ownership of your contributed code and intellectual property.  As the owner, you are free to use your code in other work, obtain patents, or do anything else you choose with it.

If you haven't already signed the agreement and been added to our public [Contributors repo](https://github.com/mycroftAI/contributors) then please head to https://mycroft.ai/cla to initiate the signing process.
