### PR TITLE
Add a card delegate

### DIFF
--- a/import/mycroft.qrc
+++ b/import/mycroft.qrc
@@ -12,6 +12,7 @@
         <file>qml/SlidingImage.qml</file>
         <file>qml/StatusIndicator.qml</file>
         <file>qml/VideoPlayer.qml</file>
+        <file>qml/CardDelegate.qml</file>
         <file>qml/private/ImageBackground.qml</file>
     </qresource>
 </RCC>

--- a/import/mycroftplugin.cpp
+++ b/import/mycroftplugin.cpp
@@ -88,6 +88,7 @@ void MycroftPlugin::registerTypes(const char *uri)
     qmlRegisterType(QUrl(QStringLiteral("qrc:/qml/StatusIndicator.qml")), uri, 1, 0, "StatusIndicator");
     qmlRegisterType(QUrl(QStringLiteral("qrc:/qml/VideoPlayer.qml")), uri, 1, 0, "VideoPlayer");
     qmlRegisterType(QUrl(QStringLiteral("qrc:/qml/BoxLayout.qml")), uri, 1, 0, "BoxLayout");
+    qmlRegisterType(QUrl(QStringLiteral("qrc:/qml/CardDelegate.qml")), uri, 1, 0, "CardDelegate");
 
     qmlRegisterUncreatableType<ActiveSkillsModel>(uri, 1, 0, "ActiveSkillsModel", QStringLiteral("You cannot instantiate items of type ActiveSkillsModel"));
     qmlRegisterUncreatableType<DelegatesModel>(uri, 1, 0, "DelegatesModel", QStringLiteral("You cannot instantiate items of type DelegatesModel"));

--- a/import/qml/CardDelegate.qml
+++ b/import/qml/CardDelegate.qml
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2021 by Aditya Mehra <aix.m@outlook.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import QtQuick 2.12
+import QtQuick.Layouts 1.12
+import QtQuick.Controls 2.12 as Controls
+import org.kde.kirigami 2.12 as Kirigami
+import QtGraphicalEffects 1.12
+
+Delegate {
+    id: root
+    leftPadding: 0
+    bottomPadding: 0
+    topPadding: 0
+    rightPadding: 0
+    
+    // Allows cards to set the background image of only the card
+    // Allows setting a color overlay for card background
+    property alias cardBackgoundBorderColor: cardBackgound.color
+    property alias cardBackgroundOverlayColor: backgroundColor.color
+    property alias cardBackgroundImage: backgroundImage.source
+    
+    // Cards always control the padding and actual card radius
+    // This allows the card to be set as fullscreen or squared
+    property int cardLeftPadding: 30
+    property int cardRightPadding: 30
+    property int cardTopPadding: 30
+    property int cardBottomPadding: 35
+    property int cardRadius: 20
+    
+    background: Rectangle {
+        id: cardBackgound
+        anchors.fill: parent
+        color: "black"
+        z: 1
+            
+        Image {
+            id: backgroundImage
+            anchors.fill: parent
+            anchors.leftMargin: cardLeftPadding
+            anchors.rightMargin: cardRightPadding
+            anchors.topMargin: cardTopPadding
+            anchors.bottomMargin: cardBottomPadding
+            source: ""
+            layer.enabled: true
+            layer.effect: OpacityMask {
+                maskSource: Rectangle {
+                    width: backgroundImage.width
+                    height: backgroundImage.height
+                    visible: false
+                    radius: cardRadius
+                }
+            }
+        }
+        
+        Rectangle {
+            id: backgroundColor
+            anchors.fill: parent
+            anchors.leftMargin: cardLeftPadding
+            anchors.rightMargin: cardRightPadding
+            anchors.topMargin: cardTopPadding
+            anchors.bottomMargin: cardBottomPadding
+            color: Qt.rgba(255, 255, 255, 0.5)
+            radius: cardRadius
+        }
+    }
+
+    contentItem: Controls.Control {
+        z: 2
+        // Make sure any content always fits inside the card content item
+        anchors.fill: parent
+        anchors.leftMargin: cardLeftPadding
+        anchors.rightMargin: cardRightPadding
+        anchors.topMargin: cardTopPadding
+        anchors.bottomMargin: cardBottomPadding
+    }
+}

--- a/import/qml/CardDelegate.qml
+++ b/import/qml/CardDelegate.qml
@@ -28,6 +28,11 @@ Delegate {
     topPadding: 0
     rightPadding: 0
     
+    rightInset: cardRightPadding
+    leftInset: cardLeftPadding
+    topInset: cardTopPadding
+    bottomInset: cardBottomPadding
+    
     // Allows cards to set the background image of only the card
     // Allows setting a color overlay for card background
     property alias cardBackgoundBorderColor: cardBackgound.color
@@ -79,13 +84,7 @@ Delegate {
         }
     }
 
-    contentItem: Controls.Control {
+    contentItem: Item {
         z: 2
-        // Make sure any content always fits inside the card content item
-        anchors.fill: parent
-        anchors.leftMargin: cardLeftPadding
-        anchors.rightMargin: cardRightPadding
-        anchors.topMargin: cardTopPadding
-        anchors.bottomMargin: cardBottomPadding
     }
 }

--- a/import/qml/CardDelegate.qml
+++ b/import/qml/CardDelegate.qml
@@ -39,7 +39,6 @@ Delegate {
     // Allows setting a color overlay for card background
     property alias cardBackgoundOverlayColor: cardBackgound.color
     property alias cardBackgroundImage: backgroundImage.source
-    property bool isbgvisible: backgroundImage.visible
     property int cardRadius: 20
     
     background: Rectangle {

--- a/import/qml/CardDelegate.qml
+++ b/import/qml/CardDelegate.qml
@@ -28,23 +28,16 @@ Delegate {
     topPadding: 0
     rightPadding: 0
     
-    rightInset: cardRightPadding
-    leftInset: cardLeftPadding
-    topInset: cardTopPadding
-    bottomInset: cardBottomPadding
+    rightInset: 30
+    leftInset: 30
+    topInset: 30
+    bottomInset: 35
     
     // Allows cards to set the background image of only the card
     // Allows setting a color overlay for card background
     property alias cardBackgoundBorderColor: cardBackgound.color
     property alias cardBackgroundOverlayColor: backgroundColor.color
     property alias cardBackgroundImage: backgroundImage.source
-    
-    // Cards always control the padding and actual card radius
-    // This allows the card to be set as fullscreen or squared
-    property int cardLeftPadding: 30
-    property int cardRightPadding: 30
-    property int cardTopPadding: 30
-    property int cardBottomPadding: 35
     property int cardRadius: 20
     
     background: Rectangle {
@@ -56,10 +49,10 @@ Delegate {
         Image {
             id: backgroundImage
             anchors.fill: parent
-            anchors.leftMargin: cardLeftPadding
-            anchors.rightMargin: cardRightPadding
-            anchors.topMargin: cardTopPadding
-            anchors.bottomMargin: cardBottomPadding
+            anchors.leftMargin: root.leftInset
+            anchors.rightMargin: root.rightInset
+            anchors.topMargin: root.topInset
+            anchors.bottomMargin: root.bottomInset
             source: ""
             layer.enabled: true
             layer.effect: OpacityMask {
@@ -75,10 +68,10 @@ Delegate {
         Rectangle {
             id: backgroundColor
             anchors.fill: parent
-            anchors.leftMargin: cardLeftPadding
-            anchors.rightMargin: cardRightPadding
-            anchors.topMargin: cardTopPadding
-            anchors.bottomMargin: cardBottomPadding
+            anchors.leftMargin: root.leftInset
+            anchors.rightMargin: root.rightInset
+            anchors.topMargin: root.topInset
+            anchors.bottomMargin: root.bottomInset
             color: Qt.rgba(255, 255, 255, 0.5)
             radius: cardRadius
         }

--- a/import/qml/CardDelegate.qml
+++ b/import/qml/CardDelegate.qml
@@ -28,6 +28,8 @@ Delegate {
     topPadding: 0
     rightPadding: 0
     
+    skillBackgroundColorOverlay: "black"
+    
     rightInset: 30
     leftInset: 30
     topInset: 30
@@ -35,26 +37,23 @@ Delegate {
     
     // Allows cards to set the background image of only the card
     // Allows setting a color overlay for card background
-    property alias cardBackgoundBorderColor: cardBackgound.color
-    property alias cardBackgroundOverlayColor: backgroundColor.color
+    property alias cardBackgoundOverlayColor: cardBackgound.color
     property alias cardBackgroundImage: backgroundImage.source
+    property bool isbgvisible: backgroundImage.visible
     property int cardRadius: 20
     
     background: Rectangle {
         id: cardBackgound
-        anchors.fill: parent
-        color: "black"
-        z: 1
-            
+        radius: cardRadius
+        color: Qt.rgba(255, 255, 255, 0.1)
+        
         Image {
             id: backgroundImage
             anchors.fill: parent
-            anchors.leftMargin: root.leftInset
-            anchors.rightMargin: root.rightInset
-            anchors.topMargin: root.topInset
-            anchors.bottomMargin: root.bottomInset
+            z: -1
             source: ""
-            layer.enabled: true
+            visible: source != "" ? 1 : 0 
+            layer.enabled: source != "" ? 1 : 0
             layer.effect: OpacityMask {
                 maskSource: Rectangle {
                     width: backgroundImage.width
@@ -63,17 +62,6 @@ Delegate {
                     radius: cardRadius
                 }
             }
-        }
-        
-        Rectangle {
-            id: backgroundColor
-            anchors.fill: parent
-            anchors.leftMargin: root.leftInset
-            anchors.rightMargin: root.rightInset
-            anchors.topMargin: root.topInset
-            anchors.bottomMargin: root.bottomInset
-            color: Qt.rgba(255, 255, 255, 0.5)
-            radius: cardRadius
         }
     }
 


### PR DESCRIPTION
#### Description
- This delegate provides a card background design. 
- The card delegate supports setting a background image or background color via color overlay for the card item.
- The card delegate supports setting a custom card item radius, in case anyone wants to do square cards or full screen cards

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
_Either delete those that do not apply, or add an x between the square brackets like so: `- [x]`_
- [ ] Bugfix
- [x] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing

```
Mycroft.CardDelegate {
    id: rexample
    cardBackgoundOverlayColor: Qt.rgba(0, 0, 0, 0.5)
    cardBackgroundImage: "someimage.png"

    Text {
        color: "white"
        text: "This Is Sample Content"
    }
}
```

#### Supported Properties

``` 
cardBackgoundOverlayColor: Qt.rgba(255, 255, 255, 0.5) (Default)
cardBackgroundImage: "" (Default: Empty)
cardRadius: 20 (Default As Per Figma)
```