### PR TITLE
Add support for sending missing context field on main messagebus

### DIFF
--- a/application/SettingsPage.qml
+++ b/application/SettingsPage.qml
@@ -128,5 +128,11 @@ Kirigami.ScrollablePage {
             onCheckedChanged: Mycroft.GlobalSettings.usesRemoteTTS = checked
             visible: Mycroft.GlobalSettings.displayRemoteConfig
         }
+
+        Controls.Switch {
+            text: "Hivemind Protocol"
+            checked: Mycroft.GlobalSettings.useHivemindProtocol
+            onCheckedChanged: Mycroft.GlobalSettings.useHivemindProtocol = checked
+        }
     }
 }

--- a/import/globalsettings.cpp
+++ b/import/globalsettings.cpp
@@ -88,3 +88,18 @@ void GlobalSettings::setUsePTTClient(bool usePTTClient)
     m_settings.setValue(QStringLiteral("usePTTClient"), usePTTClient);
     emit usePTTClientChanged();
 }
+
+bool GlobalSettings::useHivemindProtocol() const
+{
+    return m_settings.value(QStringLiteral("useHivemindProtocol"), false).toBool();
+}
+
+void GlobalSettings::setUseHivemindProtocol(bool useHivemindProtocol)
+{
+    if (GlobalSettings::useHivemindProtocol() == useHivemindProtocol) {
+        return;
+    }
+
+    m_settings.setValue(QStringLiteral("useHivemindProtocol"), useHivemindProtocol);
+    emit useHivemindProtocolChanged();
+}

--- a/import/globalsettings.h
+++ b/import/globalsettings.h
@@ -35,6 +35,7 @@ class GlobalSettings : public QObject
     Q_PROPERTY(bool usesRemoteTTS READ usesRemoteTTS WRITE setUsesRemoteTTS NOTIFY usesRemoteTTSChanged)
     Q_PROPERTY(bool displayRemoteConfig READ displayRemoteConfig WRITE setDisplayRemoteConfig NOTIFY displayRemoteConfigChanged)
     Q_PROPERTY(bool usePTTClient READ usePTTClient WRITE setUsePTTClient NOTIFY usePTTClient)
+    Q_PROPERTY(bool useHivemindProtocol READ useHivemindProtocol WRITE setUseHivemindProtocol NOTIFY useHivemindProtocolChanged)
 
 public:
     explicit GlobalSettings(QObject *parent=0);
@@ -52,6 +53,8 @@ public:
     void setDisplayRemoteConfig(bool displayRemoteConfig);
     bool usePTTClient() const;
     void setUsePTTClient(bool usePttClient);
+    bool useHivemindProtocol() const;
+    void setUseHivemindProtocol(bool useHivemindProtocol);
 
 Q_SIGNALS:
     void webSocketChanged();
@@ -59,6 +62,7 @@ Q_SIGNALS:
     void usesRemoteTTSChanged();
     void displayRemoteConfigChanged();
     void usePTTClientChanged();
+    void useHivemindProtocolChanged();
 
 private:
     QSettings m_settings;

--- a/import/mycroftcontroller.h
+++ b/import/mycroftcontroller.h
@@ -99,8 +99,8 @@ public Q_SLOTS:
     void start();
     void disconnectSocket();
     void reconnect();
-    void sendRequest(const QString &type, const QVariantMap &data);
-    void sendBinary(const QString &type, const QJsonObject &data);
+    void sendRequest(const QString &type, const QVariantMap &data, const QVariantMap &context = QVariantMap({}));
+    void sendBinary(const QString &type, const QJsonObject &data, const QVariantMap &context = QVariantMap({}));
     void sendText(const QString &message);
     void startPTTClient();
 


### PR DESCRIPTION
Context fields were previously ignored from being sent as they weren't previously useful but have always been part of the messagebus message format

-  Hivemind makes use of the context message to route incoming messages to Mycroft core in the mesh network by adding source and destination fields
- This PR adds the sending  of context messages only if hivemind protocol is enabled in the Global Settings as too safeguard all other implementations using the sendRequest and sendBinary functions from Mycroft Connect
- Context messages are by default set to as empty when not used
- Only sendText function utilized by the text field in the Mycroft GUI application sends the context fields in the message currently 