### PR TITLE
bus_isolation

### DIFF
--- a/application/SettingsPage.qml
+++ b/application/SettingsPage.qml
@@ -130,7 +130,7 @@ Kirigami.ScrollablePage {
         }
 
         Controls.Switch {
-            text: "Hivemind Protocol"
+            text: "Bus Isolation"
             checked: Mycroft.GlobalSettings.useHivemindProtocol
             onCheckedChanged: Mycroft.GlobalSettings.useHivemindProtocol = checked
         }

--- a/import/mycroftcontroller.cpp
+++ b/import/mycroftcontroller.cpp
@@ -371,9 +371,9 @@ void MycroftController::sendBinary(const QString &type, const QJsonObject &data,
 void MycroftController::sendText(const QString &message)
 {
     if(!m_appSettingObj->useHivemindProtocol()){
-        sendRequest(QStringLiteral("recognizer_loop:utterance"), QVariantMap({{QStringLiteral("utterances"), QStringList({message})}}));
-    } else {
         sendRequest(QStringLiteral("recognizer_loop:utterance"), QVariantMap({{QStringLiteral("utterances"), QStringList({message})}}), QVariantMap({{QStringLiteral("source"), QStringLiteral("debug_cli")}, {QStringLiteral("destination"), QStringLiteral("skills")}}));
+    } else {
+        sendRequest(QStringLiteral("recognizer_loop:utterance"), QVariantMap({{QStringLiteral("utterances"), QStringList({message})}}), QVariantMap({{QStringLiteral("source"), QStringLiteral("mycroft-gui")}, {QStringLiteral("destination"), QStringLiteral("skills")}}));
     }
 }
 


### PR DESCRIPTION
this renames the setting so it is not confused with https://github.com/JarbasHiveMind/HiveMind-core/wiki/Hive-Messages  The hivemind protocol exists and does a different thing, would be confusing to have that name for the setting

this message.context is mycroft-core functionality, not hivemind, more docs here https://github.com/JarbasHiveMind/HiveMind-core/wiki/Mycroft-Messages , i believe gez is adding this to official docs but they dont exist yet, original PR here https://github.com/MycroftAI/mycroft-core/pull/2461

when enabled TTS will NOT be executed in mycroft-core, when disabled behavior remains the same as always. This goes great with the remote STT/TTS settings

example use case:
- connect GUI to a remote device (different room or a server)
- remote device will not speak out loud the answer
- mycroft-gui will speak the answer