### PR TITLE
forward current track status to core backend

### DIFF
--- a/import/mediaservice.cpp
+++ b/import/mediaservice.cpp
@@ -224,6 +224,11 @@ QMediaPlayer::State MediaService::playbackState() const
 void MediaService::onMediaStatusChanged(QMediaPlayer::MediaStatus status)
 {
     emit mediaStatusChanged(status);
+
+    m_currentMediaStatus.clear();
+    m_currentMediaStatus.insert(QStringLiteral("status"), status);
+    m_controller->sendRequest(QStringLiteral("gui.player.media.service.current.media.status"), m_currentMediaStatus);
+
     if (status == QMediaPlayer::LoadedMedia || status == QMediaPlayer::BufferedMedia)
     {
         QStringList metadataAvailableList = m_player->availableMetaData();

--- a/import/mediaservice.h
+++ b/import/mediaservice.h
@@ -93,6 +93,7 @@ private:
     bool m_repeat;
     QVariantMap m_metadataList;
     QVariantMap m_playerStateSync;
+    QVariantMap m_currentMediaStatus;
 
 signals:
     int levels(double left, double right);


### PR DESCRIPTION
Forward current track status as defined in https://doc.qt.io/qt-5/qmediaplayer.html#MediaStatus-enum to core backend for tracking.
