### PR TITLE
Add missing Ubuntu dependency - qml-module-qtmultimedia

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -71,10 +71,10 @@ neon() {
 kubuntu() {
     echo "Starting Installation For K/Ubuntu 20.04 +"
     echo ""
-    echo "Following Packages Will Be Installed: git-core g++ cmake extra-cmake-modules gettext pkg-config qml-module-qtwebengine pkg-kde-tools qtbase5-dev qtdeclarative5-dev libkf5kio-dev libqt5websockets5-dev libkf5i18n-dev libkf5notifications-dev libkf5plasma-dev libqt5webview5-dev"
+    echo "Following Packages Will Be Installed: git-core g++ cmake extra-cmake-modules gettext pkg-config qml-module-qtwebengine pkg-kde-tools qtbase5-dev qtdeclarative5-dev libkf5kio-dev libqt5websockets5-dev libkf5i18n-dev libkf5notifications-dev libkf5plasma-dev libqt5webview5-dev qtmultimedia5-dev qml-module-qtmultimedia"
     echo ""
     echo "Please Enter Authentication For Installing System Dependencies"
-    sudo apt-get install -y git-core g++ cmake extra-cmake-modules gettext pkg-config qml-module-qtwebengine pkg-kde-tools qtbase5-dev qtdeclarative5-dev libkf5kio-dev libqt5websockets5-dev libkf5i18n-dev libkf5notifications-dev libkf5plasma-dev libqt5webview5-dev qtmultimedia5-dev
+    sudo apt-get install -y git-core g++ cmake extra-cmake-modules gettext pkg-config qml-module-qtwebengine pkg-kde-tools qtbase5-dev qtdeclarative5-dev libkf5kio-dev libqt5websockets5-dev libkf5i18n-dev libkf5notifications-dev libkf5plasma-dev libqt5webview5-dev qtmultimedia5-dev qml-module-qtmultimedia
     build_gui
 }
 


### PR DESCRIPTION
#### Description
Install failed on a stock Ubuntu 20.04 VM. Was missing the package: `qml-module-qtmultimedia`

#### Type of PR
- [x] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Install on Ubuntu

#### CLA
- [x] Yes