### PR TITLE
Add a marquee text component

### DIFF
--- a/import/CMakeLists.txt
+++ b/import/CMakeLists.txt
@@ -46,4 +46,4 @@ install(TARGETS mycroftplugin DESTINATION ${KDE_INSTALL_QMLDIR}/Mycroft)
 
 install(FILES qmldir DESTINATION ${KDE_INSTALL_QMLDIR}/Mycroft)
 install(DIRECTORY qml/ DESTINATION ${KDE_INSTALL_QMLDIR}/Mycroft)
-
+install(FILES plugins.qmltypes DESTINATION ${KDE_INSTALL_QMLDIR}/Mycroft)

--- a/import/mycroft.qrc
+++ b/import/mycroft.qrc
@@ -16,6 +16,7 @@
         <file>qml/Units.qml</file>
         <file>qml/SoundEffects.qml</file>
         <file>qml/BusyIndicator.qml</file>
+        <file>qml/MarqueeText.qml</file>
         <file>qml/private/ImageBackground.qml</file>
     </qresource>
 </RCC>

--- a/import/mycroftplugin.cpp
+++ b/import/mycroftplugin.cpp
@@ -102,6 +102,7 @@ void MycroftPlugin::registerTypes(const char *uri)
     qmlRegisterType(QUrl(QStringLiteral("qrc:/qml/BoxLayout.qml")), uri, 1, 0, "BoxLayout");
     qmlRegisterType(QUrl(QStringLiteral("qrc:/qml/CardDelegate.qml")), uri, 1, 0, "CardDelegate");
     qmlRegisterType(QUrl(QStringLiteral("qrc:/qml/BusyIndicator.qml")), uri, 1, 0, "BusyIndicator");
+    qmlRegisterType(QUrl(QStringLiteral("qrc:/qml/MarqueeText.qml")), uri, 1, 0, "MarqueeText");
 
     qmlRegisterUncreatableType<ActiveSkillsModel>(uri, 1, 0, "ActiveSkillsModel", QStringLiteral("You cannot instantiate items of type ActiveSkillsModel"));
     qmlRegisterUncreatableType<DelegatesModel>(uri, 1, 0, "DelegatesModel", QStringLiteral("You cannot instantiate items of type DelegatesModel"));

--- a/import/plugins.qmltypes
+++ b/import/plugins.qmltypes
@@ -542,14 +542,16 @@ Module {
         Property { name: "speed"; type: "int" }
         Property { name: "delay"; type: "int" }
         Property { name: "marqueeWidth"; type: "QVariant" }
+        Property { name: "righToLeft"; type: "bool" }
+        Property { name: "distance"; type: "int" }
         Property { name: "color"; type: "QColor" }
         Property { name: "text"; type: "string" }
         Property { name: "font"; type: "QFont" }
         Property { name: "minimumPointSize"; type: "int" }
         Property { name: "minimumPixelSize"; type: "int" }
         Property { name: "fontSizeMode"; type: "int" }
-        Property { name: "horizontalAlignment"; type: "int" }
         Property { name: "verticalAlignment"; type: "int" }
+        Property { name: "paintedWidth"; type: "double"; isReadonly: true }
         Method { name: "reset"; type: "QVariant" }
     }
     Component {

--- a/import/plugins.qmltypes
+++ b/import/plugins.qmltypes
@@ -533,6 +533,26 @@ Module {
         Signal { name: "backRequested" }
     }
     Component {
+        prototype: "QQuickItem"
+        name: "Mycroft/MarqueeText 1.0"
+        exports: ["Mycroft/MarqueeText 1.0"]
+        exportMetaObjectRevisions: [0]
+        isComposite: true
+        defaultProperty: "data"
+        Property { name: "speed"; type: "int" }
+        Property { name: "delay"; type: "int" }
+        Property { name: "marqueeWidth"; type: "QVariant" }
+        Property { name: "color"; type: "QColor" }
+        Property { name: "text"; type: "string" }
+        Property { name: "font"; type: "QFont" }
+        Property { name: "minimumPointSize"; type: "int" }
+        Property { name: "minimumPixelSize"; type: "int" }
+        Property { name: "fontSizeMode"; type: "int" }
+        Property { name: "horizontalAlignment"; type: "int" }
+        Property { name: "verticalAlignment"; type: "int" }
+        Method { name: "reset"; type: "QVariant" }
+    }
+    Component {
         prototype: "QQuickFlickable"
         name: "Mycroft/PaginatedText 1.0"
         exports: ["Mycroft/PaginatedText 1.0"]

--- a/import/qml/MarqueeText.qml
+++ b/import/qml/MarqueeText.qml
@@ -14,6 +14,8 @@ Item {
     property int speed: 1000
     property int delay: 1000
     property var marqueeWidth: width
+    property bool rightToLeft: false
+    property alias elide: marqueeText.elide
 
     onWidthChanged: {
         marqueeWidth = width
@@ -77,13 +79,13 @@ Item {
                 target: marqueeText
                 property: "x"
                 from: 0
-                to: marqueeWidth
+                to: !rightToLeft ? marqueeWidth : -marqueeWidth
                 duration: speed
             }
             PropertyAnimation {
                 target: coverText
                 property: "x"
-                from: control.x - marqueeWidth
+                from: !rightToLeft ? control.x - marqueeWidth : control.x + marqueeWidth
                 to: marqueeText.x
                 duration: speed
             }

--- a/import/qml/MarqueeText.qml
+++ b/import/qml/MarqueeText.qml
@@ -9,13 +9,13 @@ Item {
     property alias minimumPointSize: marqueeText.minimumPointSize
     property alias minimumPixelSize: marqueeText.minimumPixelSize
     property alias fontSizeMode: marqueeText.fontSizeMode
-    property alias horizontalAlignment: marqueeText.horizontalAlignment
     property alias verticalAlignment: marqueeText.verticalAlignment
-    property int speed: 1000
-    property int delay: 1000
+    property alias paintedWidth: marqueeText.paintedWidth
+    property int speed: 4000
+    property int delay: 4000
     property var marqueeWidth: width
-    property bool rightToLeft: false
-    property alias elide: marqueeText.elide
+    property bool righToLeft: false
+    property int distance: marqueeWidth / 2
 
     onWidthChanged: {
         marqueeWidth = width
@@ -28,11 +28,12 @@ Item {
             marqueeText.width = control.marqueeWidth
             marqueeText.x = control.x
             coverText.width = marqueeText.width
-            coverText.x = 0 - marqueeWidth
+            coverText.x = marqueeText.width
             marqueeAnimator.start()
         } else {
             marqueeAnimator.start()
         }
+        marqueeAnimator.start()
         marqueeText.enabled = false
         marqueeText.enabled = true
     }
@@ -44,19 +45,20 @@ Item {
 
         onHorizontalAlignmentChanged: {
             if(rtlDetector.horizontalAlignment == Text.AlignRight) {
-                rightToLeft = true;
+                leftToRight = true;
             }
         }
     }
 
     Text {
         id: marqueeText;
-        horizontalAlignment: Text.AlignHCenter
+        horizontalAlignment: Text.AlignHLeft
         verticalAlignment: Text.AlignVCenter
         height: parent.height
         width: parent.width
-        elide: Text.ElideRight
+        elide: Text.ElideNone
         text: rtlDetector.text
+        visible: x < parent.width ? 1 : 0
     }
 
     Text {
@@ -73,6 +75,7 @@ Item {
         minimumPointSize: marqueeText.minimumPointSize
         minimumPixelSize: marqueeText.minimumPixelSize
         fontSizeMode: marqueeText.fontSizeMode
+        opacity: 0
     }
 
     SequentialAnimation {
@@ -81,24 +84,31 @@ Item {
         running: false
 
         PropertyAnimation {
+            id: marqueeAnimatorDelayAnimator
             target: marqueeText
             property: "opacity"
             from: 1
             to: 1
             duration: control.delay
         }
+
+        ScriptAction {
+            script: coverText.opacity = 1
+        }
+
         ParallelAnimation {
             PropertyAnimation {
                 target: marqueeText
                 property: "x"
                 from: 0
-                to: !rightToLeft ? marqueeWidth : -marqueeWidth
+                to: !righToLeft ? (control.x + marqueeText.paintedWidth) + distance : (control.x - marqueeText.paintedWidth) - distance
                 duration: speed
             }
+
             PropertyAnimation {
                 target: coverText
                 property: "x"
-                from: !rightToLeft ? control.x - marqueeWidth : control.x + marqueeWidth
+                from: !righToLeft ? (control.x - marqueeText.paintedWidth) - distance  : (control.x + marqueeText.paintedWidth) + distance
                 to: marqueeText.x
                 duration: speed
             }

--- a/import/qml/MarqueeText.qml
+++ b/import/qml/MarqueeText.qml
@@ -1,0 +1,92 @@
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+
+Item {
+    id: control
+    property alias color: marqueeText.color
+    property alias text: marqueeText.text
+    property alias font: marqueeText.font
+    property alias minimumPointSize: marqueeText.minimumPointSize
+    property alias minimumPixelSize: marqueeText.minimumPixelSize
+    property alias fontSizeMode: marqueeText.fontSizeMode
+    property alias horizontalAlignment: marqueeText.horizontalAlignment
+    property alias verticalAlignment: marqueeText.verticalAlignment
+    property int speed: 1000
+    property int delay: 1000
+    property var marqueeWidth: width
+
+    onWidthChanged: {
+        marqueeWidth = width
+        reset()
+    }
+
+    function reset() {
+        if(marqueeAnimator.running) {
+            marqueeAnimator.stop()
+            marqueeText.width = control.marqueeWidth
+            marqueeText.x = control.x
+            coverText.width = marqueeText.width
+            coverText.x = 0 - marqueeWidth
+            marqueeAnimator.start()
+        } else {
+            marqueeAnimator.start()
+        }
+        marqueeText.enabled = false
+        marqueeText.enabled = true
+    }
+
+    Text {
+        id: marqueeText;
+        horizontalAlignment: Text.AlignHCenter
+        verticalAlignment: Text.AlignVCenter
+        height: parent.height
+        width: parent.width
+        elide: Text.ElideRight
+    }
+
+    Text {
+        id: coverText;
+        horizontalAlignment: marqueeText.horizontalAlignment
+        verticalAlignment: marqueeText.verticalAlignment
+        height: marqueeText.height
+        width: marqueeText.width
+        elide: marqueeText.elide
+        x: marqueeText.x - marqueeText.width
+        font: marqueeText.font
+        color: marqueeText.color
+        text: marqueeText.text
+        minimumPointSize: marqueeText.minimumPointSize
+        minimumPixelSize: marqueeText.minimumPixelSize
+        fontSizeMode: marqueeText.fontSizeMode
+    }
+
+    SequentialAnimation {
+        id: marqueeAnimator
+        loops: Animation.Infinite
+        running: false
+
+        PropertyAnimation {
+            target: marqueeText
+            property: "opacity"
+            from: 1
+            to: 1
+            duration: control.delay
+        }
+        ParallelAnimation {
+            PropertyAnimation {
+                target: marqueeText
+                property: "x"
+                from: 0
+                to: marqueeWidth
+                duration: speed
+            }
+            PropertyAnimation {
+                target: coverText
+                property: "x"
+                from: control.x - marqueeWidth
+                to: marqueeText.x
+                duration: speed
+            }
+        }
+    }
+}

--- a/import/qml/MarqueeText.qml
+++ b/import/qml/MarqueeText.qml
@@ -4,7 +4,7 @@ import QtQuick.Controls 2.12
 Item {
     id: control
     property alias color: marqueeText.color
-    property alias text: marqueeText.text
+    property alias text: rtlDetector.text
     property alias font: marqueeText.font
     property alias minimumPointSize: marqueeText.minimumPointSize
     property alias minimumPixelSize: marqueeText.minimumPixelSize
@@ -38,12 +38,25 @@ Item {
     }
 
     Text {
+        id: rtlDetector
+        visible: false
+        width: parent.width
+
+        onHorizontalAlignmentChanged: {
+            if(rtlDetector.horizontalAlignment == Text.AlignRight) {
+                rightToLeft = true;
+            }
+        }
+    }
+
+    Text {
         id: marqueeText;
         horizontalAlignment: Text.AlignHCenter
         verticalAlignment: Text.AlignVCenter
         height: parent.height
         width: parent.width
         elide: Text.ElideRight
+        text: rtlDetector.text
     }
 
     Text {


### PR DESCRIPTION

Adds a marquee text component

Usage: 

```
Mycroft.Delegate { 
    id: root

    Mycroft.MarqueeText {
        width: root.width
        height: root.height
        text: "This is example text"
        font.pixelSize: 45
        speed: 1000 //Speed in ms, lower ms for faster animation, higher ms for slower animation
        delay: 1000 //Speed in ms, delay in when animation starts playing on start and each completed round
    }
}
```

![marqueetext](https://user-images.githubusercontent.com/19663666/142976046-7e1f804d-c8be-4d39-a71f-0bb6b373b043.gif)
