### PR TITLE
refactor autofit label, use a different approach

### DIFF
--- a/import/qml/MarqueeText.qml
+++ b/import/qml/MarqueeText.qml
@@ -14,7 +14,7 @@ Item {
     property int speed: 4000
     property int delay: 4000
     property var marqueeWidth: width
-    property bool righToLeft: false
+    property bool rightToLeft: false
     property int distance: marqueeWidth / 2
 
     onWidthChanged: {


### PR DESCRIPTION
- Uses a new approach via setting fontSizeMode depending on various text factors, Fixes polish loop and crash, output is same as the previous approach

- Fixes a typo in marquee text