### PR TITLE
abs unsigned int type does not support negative integer value 

### DIFF
--- a/import/mediaservice.cpp
+++ b/import/mediaservice.cpp
@@ -55,7 +55,9 @@ void MediaService::setupProbeSource()
 {
     QAudioProbe *probe = new QAudioProbe;
     probe->setSource(m_player);
+
     connect(probe, SIGNAL(audioBufferProbed(QAudioBuffer)), this, SLOT(processBuffer(QAudioBuffer)));
+
     return;
 }
 
@@ -100,8 +102,13 @@ void MediaService::processBuffer(QAudioBuffer buffer)
 
         for(int i=0; i<buffer.frameCount(); i++){
             sample[i] = data[i].left/peakValue;
+#ifndef Q_OS_ANDROID
             levelLeft+= abs(data[i].left)/peakValue;
             levelRight+= abs(data[i].right)/peakValue;
+#else
+            levelLeft+= (data[i].left)/peakValue * ((data[i].left)/peakValue>0) - ((data[i].left)/peakValue<0);
+            levelRight+= (data[i].right)/peakValue * ((data[i].right)/peakValue>0) - ((data[i].right)/peakValue<0);
+#endif
         }
     }
 
@@ -115,8 +122,13 @@ void MediaService::processBuffer(QAudioBuffer buffer)
             peakValue=UCHAR_MAX;
         for(int i=0; i<buffer.frameCount(); i++){
             sample[i] = data[i].left/peakValue;
+#ifndef Q_OS_ANDROID
             levelLeft+= abs(data[i].left)/peakValue;
             levelRight+= abs(data[i].right)/peakValue;
+#else
+            levelLeft+= (data[i].left)/peakValue * ((data[i].left)/peakValue>0) - ((data[i].left)/peakValue<0);
+            levelRight+= (data[i].right)/peakValue * ((data[i].right)/peakValue>0) - ((data[i].right)/peakValue<0);
+#endif
         }
     }
 
@@ -129,8 +141,13 @@ void MediaService::processBuffer(QAudioBuffer buffer)
                 sample[i] = 0;
             }
             else{
+#ifndef Q_OS_ANDROID
                 levelLeft+= abs(data[i].left)/peakValue;
                 levelRight+= abs(data[i].right)/peakValue;
+#else
+                levelLeft+= (data[i].left)/peakValue * ((data[i].left)/peakValue>0) - ((data[i].left)/peakValue<0);
+                levelRight+= (data[i].right)/peakValue * ((data[i].right)/peakValue>0) - ((data[i].right)/peakValue<0);
+#endif
             }
         }
     }


### PR DESCRIPTION
- fix for compile error in kde/android-sdk, abs() function returns an error on compile when unsigned int is a negative value, calculate absolute value without abs() when compiling for android