### PR TITLE
Fix typo - 'righToLeft' should be 'rightToLeft'

### DIFF
--- a/import/plugins.qmltypes
+++ b/import/plugins.qmltypes
@@ -542,7 +542,7 @@ Module {
         Property { name: "speed"; type: "int" }
         Property { name: "delay"; type: "int" }
         Property { name: "marqueeWidth"; type: "QVariant" }
-        Property { name: "righToLeft"; type: "bool" }
+        Property { name: "rightToLeft"; type: "bool" }
         Property { name: "distance"; type: "int" }
         Property { name: "color"; type: "QColor" }
         Property { name: "text"; type: "string" }

--- a/import/qml/MarqueeText.qml
+++ b/import/qml/MarqueeText.qml
@@ -101,14 +101,14 @@ Item {
                 target: marqueeText
                 property: "x"
                 from: 0
-                to: !righToLeft ? (control.x + marqueeText.paintedWidth) + distance : (control.x - marqueeText.paintedWidth) - distance
+                to: !rightToLeft ? (control.x + marqueeText.paintedWidth) + distance : (control.x - marqueeText.paintedWidth) - distance
                 duration: speed
             }
 
             PropertyAnimation {
                 target: coverText
                 property: "x"
-                from: !righToLeft ? (control.x - marqueeText.paintedWidth) - distance  : (control.x + marqueeText.paintedWidth) + distance
+                from: !rightToLeft ? (control.x - marqueeText.paintedWidth) - distance  : (control.x + marqueeText.paintedWidth) + distance
                 to: marqueeText.x
                 duration: speed
             }


### PR DESCRIPTION
#### Description
Fixes #115 - typo - 'righToLeft' should be 'rightToLeft'.

#### Type of PR
- [x] Bugfix

#### Testing
No functional changes