### PR TITLE
Add Custom Color Scheme Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,13 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Android")
     find_package(OpenSSL REQUIRED)
 endif()
 
-find_package(KF5 ${KF5_MIN_VERSION} REQUIRED COMPONENTS I18n)
+find_package(KF5 ${KF5_MIN_VERSION} REQUIRED COMPONENTS I18n Kirigami2)
+
+if(KF5Kirigami2_VERSION VERSION_LESS 5.91.0)
+    SET(KirigamiLegacy TRUE)
+else()
+    SET(KirigamiLegacy FALSE)
+endif()
 
 if(NOT CMAKE_SYSTEM_NAME STREQUAL "Android")
     find_package(Qt5Widgets ${QT_MIN_VERSION} REQUIRED)

--- a/import/CMakeLists.txt
+++ b/import/CMakeLists.txt
@@ -13,6 +13,7 @@ set(mycroftimport_SRCS
     filereader.cpp
     audiorec.cpp
     mediaservice.cpp
+    colorscheme.cpp
     thirdparty/fftcalc.cpp
     thirdparty/fft.cpp
     )
@@ -34,6 +35,7 @@ target_link_libraries(mycroftplugin
         PUBLIC
             Qt5::Core
             Qt5::Multimedia
+            KF5::Kirigami2
             ${mycroftplugin_EXTRA_LIBS}
         PRIVATE
             Qt5::Qml

--- a/import/colorscheme.cpp
+++ b/import/colorscheme.cpp
@@ -1,0 +1,129 @@
+#include "colorscheme.h"
+#include <QSettings>
+
+
+// Version checking required as some distributions ship older Kirigami Packages
+// Maintain compatibility
+#ifdef KirigamiLegacy
+#include <Kirigami2/KirigamiPluginFactory>
+#else
+#include <Kirigami/KirigamiPluginFactory>
+#endif
+
+ColorScheme::ColorScheme(QObject *parent) 
+    : QObject(parent)
+{
+    // Usage:
+    // Mycroft.ColorScheme.primaryColor, Mycroft.ColorScheme.secondaryColor, Mycroft.ColorScheme.textColor
+
+    // Initialize an instance of the Kirigami Plugin as priority
+    // Set a pointer as soon as the platform theme is available
+    // Always before updating color config.
+
+    // Once initialized it does not get called again.
+    auto plugin = Kirigami::KirigamiPluginFactory::findPlugin();
+    if(plugin) {
+        auto platformTheme = plugin->createPlatformTheme(this);
+        if(platformTheme) {
+            m_platformTheme = platformTheme;
+        } else {
+            qWarning() << "Failed to load PlatformTheme Plugin falling back to custom theme";
+            m_platformTheme = nullptr;
+            setUseCustomTheme(true);
+        }
+    }
+    updateColorConfig();
+}
+
+QColor ColorScheme::primaryColor() const
+{
+    return m_primaryColor;
+}
+
+void ColorScheme::setPrimaryColor(const QColor &primaryColor)
+{
+    if (m_primaryColor == primaryColor)
+        return;
+
+    m_colorSchemeSettings.setValue(QStringLiteral("primaryColor"), primaryColor.name(QColor::HexArgb));
+    m_primaryColor = primaryColor;
+    emit primaryColorChanged();
+}
+
+QColor ColorScheme::secondaryColor() const
+{
+    return m_secondaryColor;
+}
+
+void ColorScheme::setSecondaryColor(const QColor &secondaryColor)
+{
+    if (m_secondaryColor == secondaryColor)
+        return;
+    
+    m_colorSchemeSettings.setValue(QStringLiteral("secondaryColor"), secondaryColor.name(QColor::HexArgb));
+    m_secondaryColor = secondaryColor;
+    emit secondaryColorChanged();
+}
+
+QColor ColorScheme::textColor() const
+{
+    return m_textColor;
+}
+
+void ColorScheme::setTextColor(const QColor &textColor)
+{
+    if (m_textColor == textColor)
+        return;
+    
+    m_colorSchemeSettings.setValue(QStringLiteral("textColor"), textColor.name(QColor::HexArgb));
+    m_textColor = textColor;
+    emit textColorChanged();
+}
+
+void ColorScheme::updateColorConfig() 
+{
+    if (useCustomTheme()) {
+        if (m_colorSchemeSettings.contains(QLatin1String("primaryColor"))) {
+                m_primaryColor = m_colorSchemeSettings.value(QLatin1String("primaryColor"), QColor(Qt::white)).value<QColor>();
+                emit primaryColorChanged();
+        }
+        if (m_colorSchemeSettings.contains(QLatin1String("secondaryColor"))) {
+                m_secondaryColor = m_colorSchemeSettings.value(QLatin1String("secondaryColor"), QColor(Qt::black)).value<QColor>();
+                emit secondaryColorChanged();
+        }
+        if (m_colorSchemeSettings.contains(QLatin1String("textColor"))) {
+                m_textColor = m_colorSchemeSettings.value(QLatin1String("textColor"), QColor(Qt::black)).value<QColor>();
+                emit textColorChanged();
+        }
+    } else {
+        if (m_platformTheme) {
+            m_platformTheme->setColorSet(Kirigami::PlatformTheme::ColorSet::Complementary);
+            setPrimaryColor(m_platformTheme->backgroundColor());
+            setSecondaryColor(m_platformTheme->highlightColor());
+            setTextColor(m_platformTheme->textColor());
+        }
+    }
+}
+
+void ColorScheme::syncConfig()
+{
+    m_colorSchemeSettings.sync();
+    updateColorConfig();
+}
+
+bool ColorScheme::useCustomTheme() const
+{
+    // Custom color theme is off by default and needs to be explicitly enabled
+    return m_colorSchemeSettings.value(QStringLiteral("useCustomTheme"), false).toBool();
+}
+
+void ColorScheme::setUseCustomTheme(bool useCustomTheme)
+{
+    if (ColorScheme::useCustomTheme() == useCustomTheme) {
+        return;
+    }
+
+    m_colorSchemeSettings.setValue(QStringLiteral("useCustomTheme"), useCustomTheme);
+    syncConfig();
+    emit useCustomThemeChanged();
+}

--- a/import/colorscheme.h
+++ b/import/colorscheme.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2018 by Aditya Mehra <aix.m@outlook.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include <QObject>
+#include <QColor>
+#include <QSettings>
+#include "globalsettings.h"
+ 
+#ifdef KirigamiLegacy
+#include <Kirigami2/PlatformTheme>
+#else
+#include <Kirigami/PlatformTheme>
+#endif
+
+class GlobalSettings;
+class QSettings;
+class ColorScheme : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QColor primaryColor READ primaryColor WRITE setPrimaryColor NOTIFY primaryColorChanged)
+    Q_PROPERTY(QColor secondaryColor READ secondaryColor WRITE setSecondaryColor NOTIFY secondaryColorChanged)
+    Q_PROPERTY(QColor textColor READ textColor WRITE setTextColor NOTIFY textColorChanged)
+    Q_PROPERTY(bool useCustomTheme READ useCustomTheme WRITE setUseCustomTheme NOTIFY useCustomThemeChanged)
+
+public:
+    explicit ColorScheme(QObject *parent = Q_NULLPTR);
+
+public Q_SLOTS:
+    QColor primaryColor() const;
+    void setPrimaryColor(const QColor &primaryColor);
+    QColor secondaryColor() const;
+    void setSecondaryColor(const QColor &secondaryColor);
+    QColor textColor() const;
+    void setTextColor(const QColor &textColor);
+    bool useCustomTheme() const;
+    void setUseCustomTheme(bool useCustomTheme);
+
+    void updateColorConfig();
+    void syncConfig();
+
+Q_SIGNALS:
+    void primaryColorChanged();
+    void secondaryColorChanged();
+    void textColorChanged();
+    void useCustomThemeChanged();
+
+private:
+    QColor m_primaryColor = QColor(Qt::white);
+    QColor m_secondaryColor = QColor(Qt::black);
+    QColor m_textColor = QColor(Qt::black);
+
+    QSettings m_colorSchemeSettings;
+    GlobalSettings m_globalSettings;
+
+    Kirigami::PlatformTheme *m_platformTheme;
+};

--- a/import/mycroftplugin.cpp
+++ b/import/mycroftplugin.cpp
@@ -29,6 +29,7 @@
 #include "sessiondatamap.h"
 #include "audiorec.h"
 #include "mediaservice.h"
+#include "colorscheme.h"
 
 #include <QQmlEngine>
 #include <QQmlContext>
@@ -75,6 +76,14 @@ static QObject *mediaServiceSingletonProvider(QQmlEngine *engine, QJSEngine *scr
     return new MediaService;
 }
 
+static QObject *colorSchemeSingletonProvider(QQmlEngine *engine, QJSEngine *scriptEngine)
+{
+    Q_UNUSED(engine)
+    Q_UNUSED(scriptEngine)
+
+    return new ColorScheme;
+}
+
 void MycroftPlugin::registerTypes(const char *uri)
 {
     Q_ASSERT(QLatin1String(uri) == QLatin1String("Mycroft"));
@@ -84,6 +93,7 @@ void MycroftPlugin::registerTypes(const char *uri)
     qmlRegisterSingletonType<FileReader>(uri, 1, 0, "FileReader", fileReaderSingletonProvider);
     qmlRegisterSingletonType<AudioRec>(uri, 1, 0, "AudioRec", audioRecSingletonProvider);
     qmlRegisterSingletonType<MediaService>(uri, 1, 0, "MediaService", mediaServiceSingletonProvider);
+    qmlRegisterSingletonType<ColorScheme>(uri, 1, 0, "ColorScheme", colorSchemeSingletonProvider);
     qmlRegisterSingletonType(QUrl(QStringLiteral("qrc:/qml/Units.qml")), uri, 1, 0, "Units");
     qmlRegisterSingletonType(QUrl(QStringLiteral("qrc:/qml/SoundEffects.qml")), uri, 1, 0, "SoundEffects");
     qmlRegisterType<AbstractSkillView>(uri, 1, 0, "AbstractSkillView");


### PR DESCRIPTION
- Color schemes allow skills to utilise a common color scheme and standardise color usage in skills, This PR adds supports for Mycroft.ColorScheme.

- Mycroft.ColorScheme provides 3 colors: 
  - Mycroft.ColorScheme.primaryColor
  - Mycroft.ColorScheme.secondaryColor
  - Mycroft.ColorScheme.textColor

- By default Mycroft.ColorScheme will use Kirigami Theme using the Complementary color set to define the three colors, mapped as when useCustomTheme is set to false:
  - Mycroft.ColorScheme.primaryColor == Kirigami.Theme.backgroundColor
  - Mycroft.ColorScheme.secondaryColor == Kirigami.Theme.highlightColor
  - Mycroft.ColorScheme.textColor == Kirigami.Theme.textColor

- Any platform can define its own set of colors by setting the "useCustomTheme" property to true and providing the color configurations in HexArgb (hexadecimal quad format #AARRGGBB where the first two represent the alpha channel)
- The configuration can be provided in /etc/xdg/kde.org/mycroft-gui.conf or /$USER/.config/kde.org/mycroft-gui.conf

Example Configuration:
```
[General]
useCustomTheme=true
primaryColor=#ff2a2e32
secondaryColor=#ff35bfa4
textColor=#fffcfcfc
```  

Example Usage In Skills:

```
Mycroft.CardDelegate {

    Rectangle {
       id: exampleRect
       ... 
       radius: 20
       color: Mycroft.ColorScheme.secondaryColor

        Button {
            ...
             background: Rectangle {
                 color: Mycroft.ColorScheme.primaryColor
             }
             contentItem: Text {
                  text: "60-30-10 Color Scheme Usage Example"
                 color: Mycroft.ColorScheme.textColor
             } 
         }
    }
} 
```
