### PR TITLE
add config options to enable/disable skill view animations

### DIFF
--- a/import/globalsettings.cpp
+++ b/import/globalsettings.cpp
@@ -103,3 +103,63 @@ void GlobalSettings::setUseHivemindProtocol(bool useHivemindProtocol)
     m_settings.setValue(QStringLiteral("useHivemindProtocol"), useHivemindProtocol);
     emit useHivemindProtocolChanged();
 }
+
+bool GlobalSettings::useEntryNameSpaceAnimation() const
+{
+    return m_settings.value(QStringLiteral("useEntryNameSpaceAnimation"), true).toBool();
+}
+
+void GlobalSettings::setUseEntryNameSpaceAnimation(bool useEntryNameSpaceAnimation)
+{
+    if (GlobalSettings::useEntryNameSpaceAnimation() == useEntryNameSpaceAnimation) {
+        return;
+    }
+
+    m_settings.setValue(QStringLiteral("useEntryNameSpaceAnimation"), useEntryNameSpaceAnimation);
+    emit useEntryNameSpaceAnimationChanged();
+}
+
+bool GlobalSettings::useExitNameSpaceAnimation() const
+{
+    return m_settings.value(QStringLiteral("useExitNameSpaceAnimation"), true).toBool();
+}
+
+void GlobalSettings::setUseExitNameSpaceAnimation(bool useExitNameSpaceAnimation)
+{
+    if (GlobalSettings::useExitNameSpaceAnimation() == useExitNameSpaceAnimation) {
+        return;
+    }
+
+    m_settings.setValue(QStringLiteral("useExitNameSpaceAnimation"), useExitNameSpaceAnimation);
+    emit useExitNameSpaceAnimationChanged();
+}
+
+bool GlobalSettings::useFocusAnimation() const
+{
+    return m_settings.value(QStringLiteral("useFocusAnimation"), true).toBool();
+}
+
+void GlobalSettings::setUseFocusAnimation(bool useFocusAnimation)
+{
+    if (GlobalSettings::useFocusAnimation() == useFocusAnimation) {
+        return;
+    }
+
+    m_settings.setValue(QStringLiteral("useFocusAnimation"), useFocusAnimation);
+    emit useFocusAnimationChanged();
+}
+
+bool GlobalSettings::useDelegateAnimation() const
+{
+    return m_settings.value(QStringLiteral("useDelegateAnimation"), true).toBool();
+}
+
+void GlobalSettings::setUseDelegateAnimation(bool useDelegateAnimation)
+{
+    if (GlobalSettings::useDelegateAnimation() == useDelegateAnimation) {
+        return;
+    }
+
+    m_settings.setValue(QStringLiteral("useDelegateAnimation"), useDelegateAnimation);
+    emit useDelegateAnimationChanged();
+}

--- a/import/globalsettings.h
+++ b/import/globalsettings.h
@@ -36,6 +36,10 @@ class GlobalSettings : public QObject
     Q_PROPERTY(bool displayRemoteConfig READ displayRemoteConfig WRITE setDisplayRemoteConfig NOTIFY displayRemoteConfigChanged)
     Q_PROPERTY(bool usePTTClient READ usePTTClient WRITE setUsePTTClient NOTIFY usePTTClient)
     Q_PROPERTY(bool useHivemindProtocol READ useHivemindProtocol WRITE setUseHivemindProtocol NOTIFY useHivemindProtocolChanged)
+    Q_PROPERTY(bool useEntryNameSpaceAnimation READ useEntryNameSpaceAnimation WRITE setUseEntryNameSpaceAnimation NOTIFY useEntryNameSpaceAnimationChanged)
+    Q_PROPERTY(bool useExitNameSpaceAnimation READ useExitNameSpaceAnimation WRITE setUseExitNameSpaceAnimation NOTIFY useExitNameSpaceAnimationChanged)
+    Q_PROPERTY(bool useFocusAnimation READ useFocusAnimation WRITE setUseFocusAnimation NOTIFY useFocusAnimationChanged)
+    Q_PROPERTY(bool useDelegateAnimation READ useDelegateAnimation WRITE setUseDelegateAnimation NOTIFY useDelegateAnimationChanged)
 
 public:
     explicit GlobalSettings(QObject *parent=0);
@@ -55,6 +59,14 @@ public:
     void setUsePTTClient(bool usePttClient);
     bool useHivemindProtocol() const;
     void setUseHivemindProtocol(bool useHivemindProtocol);
+    bool useEntryNameSpaceAnimation() const;
+    void setUseEntryNameSpaceAnimation(bool useEntryNameSpaceAnimation);
+    bool useExitNameSpaceAnimation() const;
+    void setUseExitNameSpaceAnimation(bool useExitNameSpaceAnimation);
+    bool useFocusAnimation() const;
+    void setUseFocusAnimation(bool useFocusAnimation);
+    bool useDelegateAnimation() const;
+    void setUseDelegateAnimation(bool useDelegateAnimation);
 
 Q_SIGNALS:
     void webSocketChanged();
@@ -63,6 +75,10 @@ Q_SIGNALS:
     void displayRemoteConfigChanged();
     void usePTTClientChanged();
     void useHivemindProtocolChanged();
+    void useEntryNameSpaceAnimationChanged();
+    void useExitNameSpaceAnimationChanged();
+    void useFocusAnimationChanged();
+    void useDelegateAnimationChanged();
 
 private:
     QSettings m_settings;

--- a/import/qml/SkillView.qml
+++ b/import/qml/SkillView.qml
@@ -44,11 +44,19 @@ Mycroft.AbstractSkillView {
 
     onOpenChanged: {
         if (open) {
-            closeAnimation.running = false;
-            openAnimation.restart();
+            if(Mycroft.GlobalSettings.useExitNameSpaceAnimation) {
+                closeAnimation.running = false;
+            }
+            if(Mycroft.GlobalSettings.useEntryNameSpaceAnimation) {
+                openAnimation.restart();
+            }
         } else {
-            openAnimation.running = false;
-            closeAnimation.restart();
+            if(Mycroft.GlobalSettings.useEntryNameSpaceAnimation) {
+                openAnimation.running = false;
+            }
+            if(Mycroft.GlobalSettings.useExitNameSpaceAnimation) {
+                closeAnimation.restart();
+            }
         }
     }
 
@@ -183,7 +191,9 @@ Mycroft.AbstractSkillView {
                             activeSkillsRepeater.currentDelegate = delegate;
                             if (root.open === false) {
                                 root.open = true;
-                                enterAnim.restart();
+                                if(Mycroft.GlobalSettings.useDelegateAnimation) {
+                                    enterAnim.restart();
+                                }
                             }
                         }
 
@@ -252,7 +262,9 @@ Mycroft.AbstractSkillView {
                                     if (model.delegateUi.focus) {
                                         delegatesView.currentIndex = index;
                                         if (root.width >= root.switchWidth) {
-                                            focusAnim.restart();
+                                            if(Mycroft.GlobalSettings.useFocusAnimation) {
+                                                focusAnim.restart();
+                                            }
                                         }
                                     }
                                 }


### PR DESCRIPTION
- Make animation effects in Skill View configurable

To configure animations to be turned of for example, edit /home/$USER/.config/kde.org/mycroft.gui.conf

```
[General]
useEntryNameSpaceAnimation=false
useExitNameSpaceAnimation=false
useFocusAnimation=false
useDelegateAnimation=false
```

